### PR TITLE
Fix compilation of few sensor drivers on Linux

### DIFF
--- a/firmware/src/rokix/sensors/BM1383AGLV/BM1383AGLV_drv.c
+++ b/firmware/src/rokix/sensors/BM1383AGLV/BM1383AGLV_drv.c
@@ -29,7 +29,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "sensors.h"
 #include "BM1383AGLV_drv.h"
-#include "BM1383AGLV_registers.h"
+#include "bm1383aglv_registers.h"
 
 
 /* Driver data struct */

--- a/firmware/src/rokix/sensors/KMX62/KMX62_drv.c
+++ b/firmware/src/rokix/sensors/KMX62/KMX62_drv.c
@@ -30,7 +30,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "sensors.h"
 #include "KMX62_drv.h"
 // KMX62_registers -> kmx62_registers.h
-#include "KMX62_registers.h"
+#include "kmx62_registers.h"
 
 
 /* Driver data struct */

--- a/firmware/src/rokix/sensors/KXG08/KXG08_drv.c
+++ b/firmware/src/rokix/sensors/KXG08/KXG08_drv.c
@@ -22,14 +22,13 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-
 #include <stdio.h> 
 #include <stddef.h>
 #include <stdint.h>
 
 #include "sensors.h"
 #include "KXG08_drv.h"
-#include "KXG08_registers.h"
+#include "kxg08_registers.h"
 
 
 /* Driver data struct */
@@ -617,5 +616,4 @@ uint8_t KXG08_debug_dump_regs()
 
     return RC_OK;
 }
-
 


### PR DESCRIPTION
The sensor header file names in #include directives were written
on upper-case although actual file names were on lower-case. On
case sensitive systems like Linux we face compilation errors.

Use lower-case names for BM1383AGLV, KGX08 and KMX62 register
header file names.

Signed-off-by: Matti Vaittinen <matti.vaittinen@fi.rohmeurope.com>